### PR TITLE
BUG: Effect size simulation

### DIFF
--- a/tests/test_trait_model.py
+++ b/tests/test_trait_model.py
@@ -62,20 +62,6 @@ class TestMultivariate:
         assert beta.shape == (10, 4)
         assert model.num_trait == 4
 
-    def test_large_sample(self):
-        np.random.seed(12)
-        n = 4
-        num_causal = 10000
-        mean = np.random.randn(n)
-        M = np.random.randn(n, n)
-        cov = np.dot(M, M.T)
-        model = tstrait.trait_model(distribution="multi_normal", mean=mean, cov=cov)
-        effect_size = model._sim_effect_size(num_causal, np.random.default_rng(1))
-        np.testing.assert_allclose(
-            np.cov(effect_size.T) * (num_causal**2), cov, rtol=2e-1
-        )
-        np.testing.assert_allclose(effect_size.mean(0) * num_causal, mean, rtol=1e-1)
-
 
 @pytest.mark.parametrize("num_causal", [1000])
 class TestKSTest:
@@ -95,14 +81,14 @@ class TestKSTest:
         model = tstrait.trait_model(distribution="normal", mean=loc, var=scale**2)
         effect_size = model._sim_effect_size(num_causal, np.random.default_rng(1))
         self.check_distribution(
-            effect_size, "norm", (loc / num_causal, scale / num_causal)
+            effect_size, "norm", (loc / num_causal, scale / np.sqrt(num_causal))
         )
 
     def test_exponential(self, num_causal):
         scale = 2
         model = tstrait.trait_model(distribution="exponential", scale=scale)
         effect_size = model._sim_effect_size(num_causal, np.random.default_rng(1))
-        self.check_distribution(effect_size, "expon", (0, scale / num_causal))
+        self.check_distribution(effect_size * np.sqrt(num_causal), "expon", (0, scale))
         assert np.min(effect_size) > 0
 
     def test_exponential_negative(self, num_causal):
@@ -112,8 +98,8 @@ class TestKSTest:
         )
         effect_size = model._sim_effect_size(num_causal, np.random.default_rng(1))
         assert np.min(effect_size) < 0
-        effect_size = np.abs(effect_size)
-        self.check_distribution(effect_size, "expon", (0, scale / num_causal))
+        effect_size = np.abs(effect_size) * np.sqrt(num_causal)
+        self.check_distribution(effect_size, "expon", (0, scale))
 
     def test_t(self, num_causal):
         loc = 2
@@ -122,7 +108,7 @@ class TestKSTest:
         model = tstrait.trait_model(distribution="t", mean=loc, var=scale**2, df=df)
         effect_size = model._sim_effect_size(num_causal, np.random.default_rng(1))
         self.check_distribution(
-            effect_size, "t", (df, loc / num_causal, scale / num_causal)
+            effect_size, "t", (df, loc / num_causal, scale / np.sqrt(num_causal))
         )
 
     def test_gamma(self, num_causal):
@@ -130,7 +116,9 @@ class TestKSTest:
         scale = 2
         model = tstrait.trait_model(distribution="gamma", shape=shape, scale=scale)
         effect_size = model._sim_effect_size(num_causal, np.random.default_rng(1))
-        self.check_distribution(effect_size, "gamma", (shape, 0, scale / num_causal))
+        self.check_distribution(
+            effect_size * np.sqrt(num_causal), "gamma", (shape, 0, scale)
+        )
         assert np.min(effect_size) > 0
 
     def test_gamma_negative(self, num_causal):
@@ -141,8 +129,8 @@ class TestKSTest:
         )
         effect_size = model._sim_effect_size(num_causal, np.random.default_rng(1))
         assert np.min(effect_size) < 0
-        effect_size = np.abs(effect_size)
-        self.check_distribution(effect_size, "gamma", (shape, 0, scale / num_causal))
+        effect_size = np.abs(effect_size) * np.sqrt(num_causal)
+        self.check_distribution(effect_size, "gamma", (shape, 0, scale))
 
     def test_multivariate(self, num_causal):
         np.random.seed(20)
@@ -156,12 +144,14 @@ class TestKSTest:
             self.check_distribution(
                 effect_size[:, i],
                 "norm",
-                (mean[i] / num_causal, np.sqrt(cov[i, i]) / num_causal),
+                (mean[i] / num_causal, np.sqrt(cov[i, i] / num_causal)),
             )
         const = np.random.randn(n)
         data = np.matmul(effect_size, const)
         data_val = np.matmul(const, cov)
         data_sd = np.sqrt(np.matmul(data_val, const))
         self.check_distribution(
-            data, "norm", (np.matmul(const, mean) / num_causal, data_sd / num_causal)
+            data,
+            "norm",
+            (np.matmul(const, mean) / num_causal, data_sd / np.sqrt(num_causal)),
         )


### PR DESCRIPTION
The original code was dividing the effect sizes by the number of causal sites, which led to the simulation of traits having extremely small variance.

I modified the codes for all trait models in tstrait, such that the mean and variance of the overall phenotype are balanced.

I would really like to thank Alison for spotting this by reading the tstrait manual.