### PR TITLE
CODE: num_causal

### DIFF
--- a/tests/test_sim_trait.py
+++ b/tests/test_sim_trait.py
@@ -134,7 +134,6 @@ class TestOutputDim:
 
 
 def model_list():
-    num_causal = 1000
     loc = 2
     scale = 5
     df = 10
@@ -143,22 +142,22 @@ def model_list():
         (
             tstrait.trait_model(distribution="normal", mean=loc, var=scale**2),
             "norm",
-            (loc / num_causal, scale / num_causal),
+            (loc, scale),
         ),
         (
             tstrait.trait_model(distribution="exponential", scale=scale),
             "expon",
-            (0, scale / num_causal),
+            (0, scale),
         ),
         (
             tstrait.trait_model(distribution="t", mean=loc, var=scale**2, df=df),
             "t",
-            (df, loc / num_causal, scale / num_causal),
+            (df, loc, scale),
         ),
         (
             tstrait.trait_model(distribution="gamma", shape=shape, scale=scale),
             "gamma",
-            (shape, 0, scale / num_causal),
+            (shape, 0, scale),
         ),
     ]
 
@@ -196,9 +195,7 @@ class Test_KSTest:
         model = tstrait.trait_model(distribution="fixed", value=value)
         sim_result = tstrait.sim_trait(ts=sample_ts, num_causal=1000, model=model)
         data = sim_result.loc[sim_result.effect_size != 0]
-        np.testing.assert_allclose(
-            data["effect_size"], np.ones(len(data)) * value / 1000
-        )
+        np.testing.assert_allclose(data["effect_size"], np.ones(len(data)) * value)
 
     def test_multivariate(self, sample_ts):
         """
@@ -233,12 +230,12 @@ class Test_KSTest:
             self.check_distribution(
                 df["effect_size"],
                 "norm",
-                (mean[i] / num_causal, np.sqrt(cov[i, i]) / num_causal),
+                (mean[i], np.sqrt(cov[i, i])),
             )
             sum_data += df["effect_size"] * const[i]
 
         self.check_distribution(
             sum_data,
             "norm",
-            (np.matmul(const, mean) / num_causal, data_sd / num_causal),
+            (np.matmul(const, mean), data_sd),
         )

--- a/tests/test_trait_model.py
+++ b/tests/test_trait_model.py
@@ -71,10 +71,8 @@ class TestMultivariate:
         cov = np.dot(M, M.T)
         model = tstrait.trait_model(distribution="multi_normal", mean=mean, cov=cov)
         effect_size = model._sim_effect_size(num_causal, np.random.default_rng(1))
-        np.testing.assert_allclose(
-            np.cov(effect_size.T) * (num_causal**2), cov, rtol=2e-1
-        )
-        np.testing.assert_allclose(effect_size.mean(0) * num_causal, mean, rtol=1e-1)
+        np.testing.assert_allclose(np.cov(effect_size.T), cov, rtol=2e-1)
+        np.testing.assert_allclose(effect_size.mean(0), mean, rtol=1e-1)
 
 
 @pytest.mark.parametrize("num_causal", [1000])
@@ -94,15 +92,13 @@ class TestKSTest:
         scale = 5
         model = tstrait.trait_model(distribution="normal", mean=loc, var=scale**2)
         effect_size = model._sim_effect_size(num_causal, np.random.default_rng(1))
-        self.check_distribution(
-            effect_size, "norm", (loc / num_causal, scale / num_causal)
-        )
+        self.check_distribution(effect_size, "norm", (loc, scale))
 
     def test_exponential(self, num_causal):
         scale = 2
         model = tstrait.trait_model(distribution="exponential", scale=scale)
         effect_size = model._sim_effect_size(num_causal, np.random.default_rng(1))
-        self.check_distribution(effect_size, "expon", (0, scale / num_causal))
+        self.check_distribution(effect_size, "expon", (0, scale))
         assert np.min(effect_size) > 0
 
     def test_exponential_negative(self, num_causal):
@@ -113,7 +109,7 @@ class TestKSTest:
         effect_size = model._sim_effect_size(num_causal, np.random.default_rng(1))
         assert np.min(effect_size) < 0
         effect_size = np.abs(effect_size)
-        self.check_distribution(effect_size, "expon", (0, scale / num_causal))
+        self.check_distribution(effect_size, "expon", (0, scale))
 
     def test_t(self, num_causal):
         loc = 2
@@ -121,16 +117,14 @@ class TestKSTest:
         df = 10
         model = tstrait.trait_model(distribution="t", mean=loc, var=scale**2, df=df)
         effect_size = model._sim_effect_size(num_causal, np.random.default_rng(1))
-        self.check_distribution(
-            effect_size, "t", (df, loc / num_causal, scale / num_causal)
-        )
+        self.check_distribution(effect_size, "t", (df, loc, scale))
 
     def test_gamma(self, num_causal):
         shape = 3
         scale = 2
         model = tstrait.trait_model(distribution="gamma", shape=shape, scale=scale)
         effect_size = model._sim_effect_size(num_causal, np.random.default_rng(1))
-        self.check_distribution(effect_size, "gamma", (shape, 0, scale / num_causal))
+        self.check_distribution(effect_size, "gamma", (shape, 0, scale))
         assert np.min(effect_size) > 0
 
     def test_gamma_negative(self, num_causal):
@@ -142,7 +136,7 @@ class TestKSTest:
         effect_size = model._sim_effect_size(num_causal, np.random.default_rng(1))
         assert np.min(effect_size) < 0
         effect_size = np.abs(effect_size)
-        self.check_distribution(effect_size, "gamma", (shape, 0, scale / num_causal))
+        self.check_distribution(effect_size, "gamma", (shape, 0, scale))
 
     def test_multivariate(self, num_causal):
         np.random.seed(20)
@@ -156,12 +150,10 @@ class TestKSTest:
             self.check_distribution(
                 effect_size[:, i],
                 "norm",
-                (mean[i] / num_causal, np.sqrt(cov[i, i]) / num_causal),
+                (mean[i], np.sqrt(cov[i, i])),
             )
         const = np.random.randn(n)
         data = np.matmul(effect_size, const)
         data_val = np.matmul(const, cov)
         data_sd = np.sqrt(np.matmul(data_val, const))
-        self.check_distribution(
-            data, "norm", (np.matmul(const, mean) / num_causal, data_sd / num_causal)
-        )
+        self.check_distribution(data, "norm", (np.matmul(const, mean), data_sd))

--- a/tstrait/trait_model.py
+++ b/tstrait/trait_model.py
@@ -108,8 +108,8 @@ class TraitModelNormal(TraitModel):
         """
         num_causal = self._check_parameter(num_causal, rng)
         beta = rng.normal(
-            loc=self.mean / num_causal,
-            scale=np.sqrt(self.var) / num_causal,
+            loc=self.mean,
+            scale=np.sqrt(self.var),
             size=num_causal,
         )
         return beta
@@ -172,7 +172,7 @@ class TraitModelExponential(TraitModel):
             Simulated effect size of a causal mutation.
         """
         num_causal = self._check_parameter(num_causal, rng)
-        beta = rng.exponential(scale=self.scale / num_causal, size=num_causal)
+        beta = rng.exponential(scale=self.scale, size=num_causal)
         if self.negative:
             beta = np.multiply(rng.choice([-1, 1], size=num_causal), beta)
         return beta
@@ -228,7 +228,7 @@ class TraitModelFixed(TraitModel):
             Simulated effect size of a causal mutation.
         """
         num_causal = self._check_parameter(num_causal, rng)
-        beta = self.value / num_causal
+        beta = self.value
         return np.repeat(beta, num_causal)
 
 
@@ -291,7 +291,7 @@ class TraitModelT(TraitModel):
         """
         num_causal = self._check_parameter(num_causal, rng)
         beta = rng.standard_t(self.df, size=num_causal)
-        beta = (beta * np.sqrt(self.var) + self.mean) / num_causal
+        beta = beta * np.sqrt(self.var) + self.mean
         return beta
 
 
@@ -355,7 +355,7 @@ class TraitModelGamma(TraitModel):
             Simulated effect size of a causal mutation.
         """
         num_causal = self._check_parameter(num_causal, rng)
-        beta = rng.gamma(self.shape, self.scale, size=num_causal) / num_causal
+        beta = rng.gamma(self.shape, self.scale, size=num_causal)
         if self.negative:
             beta = np.multiply(rng.choice([-1, 1], size=num_causal), beta)
         return beta
@@ -424,7 +424,6 @@ class TraitModelMultivariateNormal(TraitModel):
         """
         num_causal = self._check_parameter(num_causal, rng)
         beta = rng.multivariate_normal(mean=self.mean, cov=self.cov, size=num_causal)
-        beta /= num_causal
         return beta
 
 


### PR DESCRIPTION
Remove the dependence on num_causal to simulate effect sizes.

@jeromekelleher Would it be possible for you to review it? I would like to incorporate it before I start building the statistical tests, etc, with the new architecture in https://github.com/tskit-dev/tstrait/issues/103