### PR TITLE
DOC: Model input

### DIFF
--- a/docs/effect-size.md
+++ b/docs/effect-size.md
@@ -117,17 +117,17 @@ The following effect size distributions are supported in tstrait, and please ref
 
    * - ``"fixed"``
      - Fixed value
-     - ``value``
+     - ``value, random_sign``
      - :py:class:`TraitModelFixed`
 
    * - ``"exponential"``
      - Exponential distribution
-     - ``scale, negative``
+     - ``scale, random_sign``
      - :py:class:`TraitModelExponential`
 
    * - ``"gamma"``
      - Gamma distribution
-     - ``shape, scale, negative``
+     - ``shape, scale, random_sign``
      - :py:class:`TraitModelGamma`
 
    * - ``"multi_normal"``


### PR DESCRIPTION
Update input parameter name of effect size models in the documentation. This was overlooked in previous pull request when we added the feature to simulate effect sizes from random signs.