### PR TITLE
CODE: normalise

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -38,6 +38,14 @@ This page provides a detailed explanation of all public tstrait objects and func
    TraitModelMultivariateNormal
 ```
 
+### Postprocessing functions
+
+```{eval-rst}
+.. autosummary::
+
+   normalise_phenotypes
+```
+
 ### Result data classes
 
 ```{eval-rst}
@@ -98,6 +106,12 @@ This page provides a detailed explanation of all public tstrait objects and func
 
 ```{eval-rst}
 .. autoclass:: tstrait.TraitModelMultivariateNormal
+```
+
+### Postprocessing functions
+
+```{eval-rst}
+.. autofunction:: tstrait.normalise_phenotypes
 ```
 
 ### Result data classes

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -148,3 +148,41 @@ plt.show()
 The environmental noise in tstrait follows a normal distribution. Please see [](phenotype_model)
 for mathematical details on the phenotype model and [](effect_size_dist) for details on
 specifying the effect size distribution.
+
+(normalise_phenotype)=
+
+## Normalise Phenotype
+
+The simulated phenotypes can be scaled by using the {func}`normalise_phenotypes` function. The function
+will first normalise the phenotype by subtracting the mean of the input phenotype from each
+value and divide it by the standard devitation of the input phenotype.
+Afterwards, it scales the normalised phenotype based on the mean and variance input.
+The output of {func}`normalise_phenotype` is a {class}`pandas.DataFrame` object with the scaled phenotypes.
+
+An example usage of this function is shown below:
+
+```{code-cell}
+
+mean = 0
+var = 1
+normalised_df = tstrait.normalise_phenotypes(phenotype_df, mean=mean, var=var)
+normalised_df.head()
+```
+
+We see that the mean and variance of the normalised phenotype are 0 and 1, as we have indicated them
+as inputs of {func}`normalise_phenotypes`.
+
+```{code-cell}
+
+print("Mean of the normalised phenotype:", mean)
+print("Variance of the normalised phenotype:", var)
+```
+
+The distribution of the normalised phenotype is shown below.
+
+```{code-cell}
+
+plt.hist(normalised_df["phenotype"], bins=40)
+plt.title("Normalised Phenotype")
+plt.show()
+```

--- a/tstrait/__init__.py
+++ b/tstrait/__init__.py
@@ -13,6 +13,7 @@ from .simulate_effect_size import (
 from .simulate_phenotype import (
     PhenotypeResult,
     sim_phenotype,
+    normalise_phenotypes,
 )  # noreorder
 from .trait_model import (
     trait_model,
@@ -34,6 +35,7 @@ from .simulate_environment import (
 __all__ = [
     "__version__",
     "sim_trait",
+    "normalise_phenotypes",
     "PhenotypeResult",
     "sim_phenotype",
     "trait_model",


### PR DESCRIPTION
Add `normalise_phenotype` function in tstrait. Statistical tests are also added to `verification.py` to validate the normalized simulated tstrait phenotype against phenotypes that are generated by using the simulation framework which is used in the ARG-Needle paper (https://zenodo.org/records/7745746).