### PR TITLE
CODE: Genetic value

### DIFF
--- a/tstrait/genetic_value.py
+++ b/tstrait/genetic_value.py
@@ -198,6 +198,8 @@ def genetic_value(ts, trait_df):
     if np.min(trait_id) != 0 or np.max(trait_id) != len(trait_id) - 1:
         raise ValueError("trait_id must be consecutive and start from 0")
 
+    trait_df = trait_df.astype({"trait_id": int})
+
     genetic = _GeneticValue(ts=ts, trait_df=trait_df)
 
     genetic_result = genetic._run()


### PR DESCRIPTION
The `genetic_value` function will produce an error when the `trait_id` column is not an integer (i.e., np.zeros() produces 0 as a float object). Change the dtype of `trait_id` to be int after all checks are completed.